### PR TITLE
Improve errorformat definitions

### DIFF
--- a/compiler/pytest.vim
+++ b/compiler/pytest.vim
@@ -18,11 +18,20 @@ set cpo-=C
 CompilerSet makeprg=py.test\ --tb=short\ -q
 
 CompilerSet errorformat=
-  \%*[_]\ %m\ %*[_],
-  \%A%>%f:%l:\ %.%#,
-  \%-Z>%*[\ ]%m,
-  \E%m,
-  \%-G%.%#
+      \%-G=%#\ ERRORS\ =%#,
+      \%-G=%#\ FAILURES\ =%#,
+      \%-G%\\s%\\*%\\d%\\+\ tests\ deselected%.%#,
+      \ERROR:\ %m,
+      \%E_%\\+\ %m\ _%\\+,
+      \%Cfile\ %f\\,\ line\ %l,
+      \%CE\ %#%m,
+      \%EE\ \ \ \ \ File\ \"%f\"\\,\ line\ %l,
+      \%ZE\ \ \ %[%^\ ]%\\@=%m,
+      \%Z%f:%l:\ %m,
+      \%Z%f:%l,
+      \%C%.%#,
+      \%-G%.%#\ seconds,
+      \%-G%.%#,
 
 let &cpo = s:cpo_save
 unlet s:cpo_save


### PR DESCRIPTION
That's what I came up with when looking into #1 and improving it in general.

Ref: https://github.com/5long/pytest-vim-compiler/pull/1
