### PR TITLE
Update the compiler plugin

### DIFF
--- a/Changelog.mkd
+++ b/Changelog.mkd
@@ -1,3 +1,8 @@
+### v0.7.0 2020-02-07
+
+* Updated the pytest command and fixed the color bug.
+* Added additional arguments support.
+
 ### v0.6.0 2013-08-03
 
 * Include detailed multi-line error message as plain message

--- a/README.mkd
+++ b/README.mkd
@@ -6,16 +6,47 @@
 
 * Download stable version at vim.org: [pytest-compiler]
 * Or, use a [plugin manager] and install from
-  <https://github.com/5long/pytest-vim-compiler>
+  <https://github.com/5long/pytest-vim-compiler>.
+  For example, with [vim-plug]:
+
+```vim
+Plug '5long/pytest-vim-compiler'
+```
 
 ## Usage
 
 Just execute `:compiler pytest` and you're done.
-Well, no. You're gonna need one of the following:
+Well, no. You're going to need one of the following:
 
-* plain `:make`. see [Vim docs for more][doc make]
+* plain `:make`. See [Vim docs for more][doc make]
 * [MakeGreen](https://github.com/reinh/vim-makegreen)
 * [dispatch.vim](https://github.com/tpope/vim-dispatch)
+
+## Configuration
+
+|           Name           |  type  | Default |
+|--------------------------|--------|---------|
+| `g:pytest_compiler_args` | string |  `""`   |
+
+If set in your vim configuration, it will always be passed to CompilerSet as
+additional arguments, saving you the trouble to manually add flags you use every
+time (for example: `--ff --junit-xml=report.xml`).
+
+You can define this at runtime as well, but you will have to call `:compiler pytest`
+again, after.
+
+Even when defined, you can still pass additional arguments with each make run.
+
+### Fixing pytest layout in Dispatch windows
+
+You'll notice that the pytest layout is broken in the quickfix window when running `:Dispatch`.
+
+To fix that, install the pytest plugin [pytest-vimqf](https://github.com/CarloDePieri/pytest-vimqf)
+and add the relative flag in your vim configuration:
+
+```vim
+let g:pytest_compiler_args = "--vim-quickfix"
+```
 
 ## License
 
@@ -23,4 +54,5 @@ MIT Licensed. See file LICENSE.
 
 [pytest-compiler]: http://www.vim.org/scripts/script.php?script_id=4508
 [plugin manager]: http://vim-scripts.org/vim/tools.html
+[vim-plug]: https://github.com/junegunn/vim-plug
 [doc make]: http://vimdoc.sourceforge.net/htmldoc/usr_30.html#30.1

--- a/compiler/pytest.vim
+++ b/compiler/pytest.vim
@@ -15,7 +15,12 @@ endif
 let s:cpo_save = &cpo
 set cpo-=C
 
-CompilerSet makeprg=pytest\ --color=no\ --tb=short\ -q
+let s:compiler_set = "CompilerSet makeprg=pytest\\ --color=no\\ --tb=short\\ -q"
+if exists('g:pytest_compiler_args')
+  let s:args = substitute(g:pytest_compiler_args, " ", "\\\\ ", "g")
+  let s:compiler_set .= "\\ " . s:args
+endif
+execute s:compiler_set
 
 CompilerSet errorformat=
       \%-G=%#\ ERRORS\ =%#,

--- a/compiler/pytest.vim
+++ b/compiler/pytest.vim
@@ -15,7 +15,7 @@ endif
 let s:cpo_save = &cpo
 set cpo-=C
 
-CompilerSet makeprg=py.test\ --tb=short\ -q
+CompilerSet makeprg=pytest\ --color=no\ --tb=short\ -q
 
 CompilerSet errorformat=
       \%-G=%#\ ERRORS\ =%#,


### PR DESCRIPTION
This compiler plugin output is currently kinda broken:
- Currently pytest bin is called 'pytest'.
- More importantly, it features colors by default: they must be disabled to take advantage of the compiler errorformat.

https://github.com/CarloDePieri/pytest-vim-compiler/commit/a296f74e7aa8bf5c4d90f39978cce3f356fadda1 solve these first points.

Now, I'm not sure the second commit has a place here, but I'm proposing it anyway; if you are not interested in it we can merge only the first one. Anyway. https://github.com/CarloDePieri/pytest-vim-compiler/commit/2a45ac39189c28a5c50c465503f9427d21bad021 introduces `g:pytest_compiler_args` and the relative documentation:
- this is usefull in its own right, when passing often the same flags to the compiler
- not so coincidentally, it also offers an easy way to apply a [fix to the broken pytest layout](https://github.com/CarloDePieri/pytest-vimqf) that results by using this compiler with `:Dispatch`